### PR TITLE
add 'autofocus' to work_title input field

### DIFF
--- a/indigo_app/templates/work/edit.html
+++ b/indigo_app/templates/work/edit.html
@@ -18,7 +18,7 @@
       <div class="form-row">
         <div class="form-group col-12">
           <label for="work_title" class="required">Short title</label>
-          <input type="text" class="form-control" id="work_title" placeholder="Title" required>
+          <input type="text" class="form-control" id="work_title" autofocus placeholder="Title" required>
         </div>
       </div>
 


### PR DESCRIPTION
this way when someone opens the 'Create a new work' page, they can start pasting immediately