### PR TITLE
Refs

### DIFF
--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -33,7 +33,8 @@ ALLOWED_HOSTS = ['*']
 
 INSTALLED_APPS = (
     # Indigo local traditions
-    'indigo_za',
+    # 'indigo_za',
+    'indigo_refs',
 
     # Indigo social
     'indigo_social',

--- a/indigo_refs/__init__.py
+++ b/indigo_refs/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'indigo_refs.apps.IndigoRefsAppConfig'

--- a/indigo_refs/apps.py
+++ b/indigo_refs/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class IndigoRefsAppConfig(AppConfig):
+    name = 'indigo_refs'
+    verbose_name = 'Indigo Refs'
+
+    def ready(self):
+        # ensure our plugins are pulled in
+        import indigo_refs.refs  # noqa

--- a/indigo_refs/refs.py
+++ b/indigo_refs/refs.py
@@ -1,0 +1,23 @@
+import re
+
+from indigo.analysis.refs.base import BaseRefsFinder
+from indigo.plugins import plugins
+
+
+@plugins.register('refs')
+class RefsFinderENGG(BaseRefsFinder):
+    """ Finds references to Acts in documents, of the form:
+
+        Act 52 of 2001
+        Act no. 52 of 1998
+
+    """
+
+    # country, language, locality
+    locale = (None, 'eng', None)
+
+    act_re = re.compile(r'\bAct,?\s+([nN]o\.?\s*)?(\d+)+\s+of\s+(\d{4})')
+    candidate_xpath = ".//text()[contains(., 'Act') and not(ancestor::a:ref)]"
+
+    def make_href(self, match):
+        return '/%s/act/%s/%s' % (self.frbr_uri.country, match.group(3), match.group(2))

--- a/indigo_za/refs.py
+++ b/indigo_za/refs.py
@@ -15,7 +15,7 @@ class RefsFinderENG(BaseRefsFinder):
     """
 
     # country, language, locality
-    locale = (None, 'eng', None)
+    locale = ('za', 'eng', None)
 
     act_re = re.compile(r'\bAct,?\s+([nN]o\.?\s*)?(\d+)+\s+of\s+(\d{4})|\bConstitution\b(\s+of(\s+the\s+Republic\s+of)?\s+South\s+Africa)?((\s+Act)?,?\s+1996)?')
     candidate_xpath = ".//text()[(contains(., 'Act') or contains(., 'Constitution')) and not(ancestor::a:ref)]"
@@ -41,7 +41,7 @@ class RefsFinderAFR(BaseRefsFinder):
     """
 
     # country, language, locality
-    locale = (None, 'afr', None)
+    locale = ('za', 'afr', None)
 
     act_re = re.compile(r'\bWet,?\s+([nN]o\.?\s*)?(\d+)+\s+van\s+(\d{4})|\bGrondwet\b(\s+van(\s+die\s+Republiek\s+van)?\s+Suid[- ]Afrika)?((\s+Wet)?,?\s+1996)?')
     candidate_xpath = ".//text()[(contains(., 'Wet') or contains(., 'Grondwet')) and not(ancestor::a:ref)]"


### PR DESCRIPTION
For interest's sake, this worked perfectly: if I had indigo_za installed, it didn't apply the SA Constitution to a work from Angola, but did for one from SA; and if I didn't have indigo_za installed, it defaulted to just finding Acts for both. so it is possible. I do think the global refs finder should have its own name though, so that if I have indigo_za installed I can still find refs for countried outside of SA?